### PR TITLE
Fixnames

### DIFF
--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -238,7 +238,7 @@ del _agentsdeps, _agentsschema
 _udeps= [('Materials', ('ResourceId', 'ObjId', 'TimeCreated', 'NucId'), 'Mass'),
          ('Transactions', ('ResourceId', ), 'Commodity')]
 
-_uschema = [('Year', ts.INT), ('FcoUMined', ts.DOUBLE)]
+_uschema = [('Year', ts.INT), ('UMined', ts.DOUBLE)]
 
 @metric(name='FcoUMined', depends=_udeps, schema=_uschema)
 def fco_u_mined(series):
@@ -265,7 +265,7 @@ def fco_u_mined(series):
     m = m.reset_index()
     # sum by years (12 time steps)
     u = pd.DataFrame(data={'Year': m.TimeCreated.apply(lambda x: x//12), 
-                           'FcoUMined': u}, columns=['Year', 'FcoUMined'])
+                           'UMined': u}, columns=['Year', 'UMined'])
     u = u.groupby('Year').sum()
     rtn = u.reset_index()
     return rtn
@@ -278,9 +278,9 @@ _egdeps = [('TimeSeriesPower', ('Time',), 'Value'),]
 
 _egschema = [('Year', ts.INT), ('Power', ts.DOUBLE)]
 
-@metric(name='FcoElectricityGen', depends=_egdeps, schema=_egschema)
-def fco_electricity_gen(series):
-    """FcoElectricityGen metric returns the electricity generated in GWe-y 
+@metric(name='FcoElectricityGenerated', depends=_egdeps, schema=_egschema)
+def fco_electricity_generated(series):
+    """FcoElectricityGenerated metric returns the electricity generated in GWe-y 
     in a 200-yr simulation. This is written for the purpose of FCO databases.
     """
     elec = series[0].reset_index()

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -94,14 +94,18 @@ def metric(name=None, depends=NotImplemented, schema=NotImplemented):
 #
 
 # Material Mass (quantity * massfrac)
-_matdeps = [('Resources', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated'), 
-                'Quantity'),
-            ('Compositions', ('SimId', 'QualId', 'NucId'), 'MassFrac')]
+_matdeps = [
+    ('Resources', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated'), 
+        'Quantity'),
+    ('Compositions', ('SimId', 'QualId', 'NucId'), 'MassFrac')
+    ]
 
-_matschema = (('SimId', ts.UUID), ('QualId', ts.INT), 
-              ('ResourceId', ts.INT), ('ObjId', ts.INT), 
-              ('TimeCreated', ts.INT), ('NucId', ts.INT), 
-              ('Mass', ts.DOUBLE))
+_matschema = [
+    ('SimId', ts.UUID), ('QualId', ts.INT), 
+    ('ResourceId', ts.INT), ('ObjId', ts.INT), 
+    ('TimeCreated', ts.INT), ('NucId', ts.INT), 
+    ('Mass', ts.DOUBLE)
+    ]
 
 @metric(name='Materials', depends=_matdeps, schema=_matschema)
 def materials(series):
@@ -121,12 +125,17 @@ del _matdeps, _matschema
 
 
 # Activity (mass * decay_const / atomic_mass)
-_actdeps = [('Materials', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated', 'NucId'), 'Mass')]
+_actdeps = [
+    ('Materials', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated', 'NucId'),
+        'Mass')
+    ]
 
-_actschema = [('SimId', ts.UUID), ('QualId', ts.INT), 
-              ('ResourceId', ts.INT), ('ObjId', ts.INT), 
-              ('TimeCreated', ts.INT), ('NucId', ts.INT), 
-              ('Activity', ts.DOUBLE)]
+_actschema = [
+    ('SimId', ts.UUID), ('QualId', ts.INT), 
+    ('ResourceId', ts.INT), ('ObjId', ts.INT), 
+    ('TimeCreated', ts.INT), ('NucId', ts.INT), 
+    ('Activity', ts.DOUBLE)
+    ]
 
 @metric(name='Activity', depends=_actdeps, schema=_actschema)
 def activity(series):
@@ -150,13 +159,17 @@ del _actdeps, _actschema
 
 
 # DecayHeat (activity * q_value)
-_dhdeps = [('Activity', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated', 'NucId'),
-               'Activity')]
+_dhdeps = [
+    ('Activity', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated', 'NucId'), 
+        'Activity')
+    ]
 
-_dhschema = [('SimId', ts.UUID), ('QualId', ts.INT), 
-             ('ResourceId', ts.INT), ('ObjId', ts.INT), 
-             ('TimeCreated', ts.INT), ('NucId', ts.INT), 
-             ('DecayHeat', ts.DOUBLE)]
+_dhschema = [
+    ('SimId', ts.UUID), ('QualId', ts.INT), 
+    ('ResourceId', ts.INT), ('ObjId', ts.INT), 
+    ('TimeCreated', ts.INT), ('NucId', ts.INT), 
+    ('DecayHeat', ts.DOUBLE)
+    ]
 
 @metric(name='DecayHeat', depends=_dhdeps, schema=_dhschema)
 def decay_heat(series):
@@ -235,8 +248,10 @@ del _agentsdeps, _agentsschema
 #########################
 
 # U Resources Mined [t] 
-_udeps= [('Materials', ('ResourceId', 'ObjId', 'TimeCreated', 'NucId'), 'Mass'),
-         ('Transactions', ('ResourceId', ), 'Commodity')]
+_udeps= [
+    ('Materials', ('ResourceId', 'ObjId', 'TimeCreated', 'NucId'), 'Mass'),
+    ('Transactions', ('ResourceId', ), 'Commodity')
+    ]
 
 _uschema = [('Year', ts.INT), ('UMined', ts.DOUBLE)]
 
@@ -245,7 +260,8 @@ def fco_u_mined(series):
     """FcoUMined metric returns the uranium mined in tonnes for each year 
     in a 200-yr simulation. This is written for FCO databases that use the 
     Bright-lite Fuel Fab(i.e., the U235 and U238 are given separately in the 
-    FCO simulations)."""
+    FCO simulations).
+    """
     mass = pd.merge(series[0].reset_index(), series[1].reset_index(), 
             on=['ResourceId'], how='inner').set_index(['ObjId', 
                 'TimeCreated', 'NucId'])
@@ -296,8 +312,10 @@ del _egdeps, _egschema
 
 
 # Annual Fuel Loading Rate [tHM/y]
-_fldeps = [('Materials', ('ResourceId', 'TimeCreated'), 'Mass'),
-          ('Transactions', ('ResourceId',), 'Commodity')]
+_fldeps = [
+    ('Materials', ('ResourceId', 'TimeCreated'), 'Mass'),
+    ('Transactions', ('ResourceId',), 'Commodity')
+    ]
 
 _flschema = [('Year', ts.INT), ('FuelLoading', ts.DOUBLE)]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -171,7 +171,7 @@ def test_decayheat():
 
 def test_fco_u_mined():
     exp = pd.DataFrame(np.array([(0, 3.780034), (1, 2.185349)], 
-        dtype=ensure_dt_bytes([('Year', '<i8'), ('FcoUMined', '<f8')]))
+        dtype=ensure_dt_bytes([('Year', '<i8'), ('UMined', '<f8')]))
         )
     mats = pd.DataFrame(np.array([
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 5, 7, 3, 3, 922350000, 8.328354),
@@ -231,7 +231,7 @@ def test_fco_fuel_loading():
     assert_frame_equal(exp, obs)
 
 
-def test_fco_electricity_gen():
+def test_fco_electricity_generated():
     exp = pd.DataFrame(np.array([(0, 3), (1, 10)], 
         dtype=ensure_dt_bytes([('Year', '<i8'), ('Power', '<f8')]))
         )
@@ -244,7 +244,7 @@ def test_fco_electricity_gen():
                 ('Value', '<f8')]))
         )
     series = [tsp.set_index(['SimId', 'AgentId', 'Time'])['Value']]
-    obs = metrics.fco_electricity_gen.func(series)
+    obs = metrics.fco_electricity_generated.func(series)
     assert_frame_equal(exp, obs)
 
 


### PR DESCRIPTION
Since no abbreviations are currently accepted, I have updated metrics names to be fully spelled out, aside from U (Uranium Mined) and FCO (for fco/bright-light-specific metrics). Feel free to make suggestions for these two I excluded updating. 