### PR TITLE
Updatets

### DIFF
--- a/genapi.py
+++ b/genapi.py
@@ -904,16 +904,19 @@ def parse_args(argv):
     ns = parser.parse_args(argv)
     return ns
 
-
 def setup(ns):
     """Ensure that we are ready to perform code generation. Returns typesystem."""
     # load raw table
     dbtypes_json = os.path.join(ns.build_dir, 'dbtypes.json')
     if not os.path.exists(ns.build_dir):
         os.mkdir(ns.build_dir)
-    if not os.path.isfile(dbtypes_json):
-        print('Downloading ' + DBTYPES_JS_URL + ' ...')
-        f = urlopen(DBTYPES_JS_URL)
+    try:
+        instdir = safe_output(['cyclus', '--install-path'])
+    except (subprocess.CalledProcessError, OSError):
+        # fallback for conda version of cyclus
+        instdir = safe_output(['cyclus_base', '--install-path']) 
+    fname = os.path.join(instdir.strip(), 'share', 'cyclus', 'dbtypes.js')
+    with io.open(fname) as f:
         raw = f.read()
         if isinstance(raw, bytes):
             raw = raw.decode()

--- a/genapi.py
+++ b/genapi.py
@@ -71,7 +71,7 @@ class TypeSystem(object):
         self.verstr = verstr = 'v{0}.{1}'.format(*cycver)
         self.cols = cols = {x: i for i, x in enumerate(table[0])}
         version = cols['version']
-        cpptype, rank = cols['C++ type'], cols['shape rank']
+        cppt_col = cols['C++ type']
         self.table = table = [row for row in table if row[version] == verstr]
         self.types = types = set()
         self.ids = ids = {}
@@ -79,7 +79,7 @@ class TypeSystem(object):
         self.ranks = ranks = {}
         i = 0
         for row in table:
-            cppt = row[cpptype]
+            cppt = row[cppt_col]
             rankt = rank(cppt)
             for t in enumtypes(cppt):
                 types.add(t)
@@ -88,8 +88,6 @@ class TypeSystem(object):
                 ranks[t] = rankt
                 i += 1
         self.norms = {t: parse_template(c) for t, c in cpptypes.items()}
-        print(self.cpptypes)
-        print(self.norms)
         self.dbtypes = sorted(types, key=lambda t: ids[t])
 
         # caches

--- a/genapi.py
+++ b/genapi.py
@@ -877,8 +877,6 @@ def typesystem_pxd(ts, ns):
 # CLI
 #
 
-DBTYPES_JS_URL = 'http://fuelcycle.org/arche/dbtypes.js'
-
 def parse_args(argv):
     """Parses typesystem arguments for code generation."""
     parser = argparse.ArgumentParser()

--- a/genapi.py
+++ b/genapi.py
@@ -77,12 +77,16 @@ class TypeSystem(object):
         self.ids = ids = {}
         self.cpptypes = cpptypes = {}
         self.ranks = ranks = {}
-        for i, row in enumerate(table):
-            t = row[cpptype]
-            types.add(t)
-            ids[t] = i
-            cpptypes[t] = row[cpptype]
-            ranks[t] = row[rank]
+        i = 0
+        for row in table:
+            cppt = row[cpptype]
+            rankt = row[rank]
+            for t in enumtypes(cppt):
+                types.add(t)
+                ids[t] = i
+                cpptypes[t] = cppt
+                ranks[t] = rankt
+                i += 1
         self.norms = {t: parse_template(c) for t, c in cpptypes.items()}
         print(self.cpptypes)
         print(self.norms)
@@ -659,6 +663,7 @@ replaces = [
     ]
 
 VLS = [
+    'STRING',
     'MAP',
     'VECTOR',
     'SET',
@@ -676,12 +681,8 @@ def enumtypes(t):
 
 def cpp_typesystem(ts, ns):
     """Creates the Cython header that wraps the Cyclus type system."""
-    y = [enumtypes(t) for t in ts.dbtypes]
-    x = list(itertools.chain(*y))
-    print(y)
-    print(x)
     ctx = dict(
-        dbtypes=x,
+        dbtypes=ts.dbtypes,
         cg_warning=CG_WARNING,
         stl_cimports=STL_CIMPORTS,
         )

--- a/genapi.py
+++ b/genapi.py
@@ -80,7 +80,7 @@ class TypeSystem(object):
         i = 0
         for row in table:
             cppt = row[cpptype]
-            rankt = row[rank]
+            rankt = rank(cppt)
             for t in enumtypes(cppt):
                 types.add(t)
                 ids[t] = i
@@ -670,6 +670,10 @@ VLS = [
     'LIST',
     'QUEUE'
     ]
+
+def rank(t):
+    rs = [t.count(x.lower()) for x in VLS]
+    return sum(rs)
 
 def enumtypes(t):
     for x, y in replaces:

--- a/genapi.py
+++ b/genapi.py
@@ -215,9 +215,19 @@ class TypeSystem(object):
             dbe_i = map(Indenter, dbe_i)
             ctx[targ+'decl'], ctx[targ+'body'], ctx[targ+'expr'] = dbe_i
             ctx['nptypes'].append(self.nptype(n_i))
-        decl = decl.format(**ctx)
-        body = body.format(**ctx)
-        expr = expr.format(**ctx)
+        errormsg = "KeyError with variable {} of type {} (in {}): {}"
+        try:
+            decl = decl.format(**ctx)
+        except KeyError as e:
+            raise Exception(errormsg.format(x, t, "declaration", e))
+        try:
+            body = body.format(**ctx)
+        except KeyError as e:
+            raise Exception(errormsg.format(x, t, "body", e))
+        try:
+            expr = expr.format(**ctx)
+        except KeyError as e:
+            raise Exception(errormsg.format(x, t, "expression", e))
         return decl, body, expr
 
     def convert_to_cpp(self, x, t):

--- a/test_genapi.py
+++ b/test_genapi.py
@@ -1,0 +1,18 @@
+import nose
+from nose.tools import assert_equal
+
+import genapi
+
+
+def test_enumtypes():
+    test = (
+        ('std::map< int,std::vector<double> >', 
+         set(['MAP_INT_VECTOR_DOUBLE', 
+              'VL_MAP_INT_VECTOR_DOUBLE',
+              'MAP_INT_VL_VECTOR_DOUBLE',
+              'VL_MAP_INT_VL_VECTOR_DOUBLE',]),
+         2,),
+        )
+    for obj, exp_t, exp_r in test:
+        yield assert_equal, exp_t, set(genapi.enumtypes(obj))
+        yield assert_equal, exp_r, genapi.rank(obj)


### PR DESCRIPTION
This is the fourth PR in a set of prs related to `dbtypes.js`. It does not work with the current `dbtypes.js` installed by cyclus in cyclus/cyclus#1184, but it *does* work with `dbtypes.js.old` that is also installed. It is depedent on cyclus/cyclus#1184.

Note that by "work" I mean: "builds and tests without error".

The (now with a better message) error that is raised on the current dbtypes.js is:
```
$ rm -r build; ./setup.py install --user && nosetests -w tests
Generating API Bindings...

--------------------

If you are having issues building cymetric, please report your problem to cyclus-dev@googlegroups.com or look for help at http://fuelcycle.org

--------------------
Traceback (most recent call last):
  File "./setup.py", line 269, in <module>
    main()
  File "./setup.py", line 240, in main
    main_body(cmake_args, make_args)
  File "./setup.py", line 214, in main_body
    genapi.main([])
  File "/home/gidden/work/cyclus/cymetric/genapi.py", line 1018, in main
    code_gen(ts, ns)
  File "/home/gidden/work/cyclus/cymetric/genapi.py", line 1001, in code_gen
    s = func(ts, ns)
  File "/home/gidden/work/cyclus/cymetric/genapi.py", line 857, in typesystem_pyx
    rtn = TYPESYSTEM_PYX.render(ctx)
  File "/home/gidden/.local/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/gidden/.local/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 93, in top-level template code
  File "/home/gidden/work/cyclus/cymetric/genapi.py", line 222, in convert_to_py
    raise Exception(errormsg.format(x, t, "declaration", e))
Exception: KeyError with variable x of type (u'std::map', u'std::string') (in declaration): u'valdecl'
```

This failure goes away if the following types are removed:
```
    '["std::map< std::string, std::pair<double, std::map<int, double> > >", 3, "SQLite", "v1.3", 1],' +
    '["std::map< int, std::map< std::string, double> >", 3, "SQLite", "v1.3", 1],' +
    '["std::map< std::string, std::vector< std::pair< int, std::pair<std::string, std::string> > > >", 5, "SQLite", "v1.3", 1],' +
    '["std::map< std::string, std::pair<double, std::map<int, double> > >", 3, "HDF5", "v1.3", 0],' +
    '["std::map< int, std::map< std::string, double> >", 3, "HDF5", "v1.3", 0],' +
    '["std::map< std::string, std::vector< std::pair< int, std::pair<std::string, std::string> > > >", 5, "HDF5", "v1.3", 0],' +
    '["std::map< std::pair<int, std::string>, double >", 2, "HDF5", "v1.3", 0],' +
```

I can not find any simple unique features that explain the bug, so I will leave it to others to contemplate. 