### PR TITLE
moving install instructions to github from the website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,68 @@
-This repository holds scripts to analyze cyclus' output and to convert it into
+This repository holds scripts to analyze Cyclus' output and to convert it into
 nuclear fuel cycle metrics.
-The nuclear data is acquired through `PyNE`_.
 
-A tutorial (including installation instructions) and the API doucmentation can be found on `fuelcycle.org`_.
+A tutorial and the API doucmentation can be found on `fuelcycle.org`_ in the
+`User Guide`_.
+
+Installing Cymetric
+----------------
+
+Cymetric is available on the same platforms as Cyclus: Ubuntu and Max OS.
+
+Dependencies
+~~~~~~~~~~~~
+First, please check to make sure you have all of the dependencies. 
+
+Required dependencies:
+
+* Cyclus and its dependencies
+* `Jinja2 <http://jinja.pocoo.org/docs/dev/>`_
+* `pandas <http://pandas.pydata.org/>`_
+* `NumPy <http://www.numpy.org/>`_
+* `matplotlib <http://matplotlib.org/index.html>`_ and matplotlib.pyplot
+
+Optional dependencies:
+
+* `PyNE`_ and its dependencies
+
+PyNE is what the Cyclus project uses for its nuclear data, and many metrics
+in cymetric depend on it. 
+
+Building from Source
+~~~~~~~~~~~~~~~~~~~~
+
+Cymetric can be built from source by first downloading the code by cloning the
+GitHub repository:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/cyclus/cymetric
+
+Then build and install:
+
+.. code-block:: bash
+
+    $ cd cymetric
+    $ python setup.py install --user
+
+Next, run the tests to ensure everything is working properly:
+
+.. code-block:: bash
+
+    $ nosetests -w tests/
+
+Installation via Binary
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The latest released version of Cymetric is available via Conda. After obtaining
+miniconda by following steps 1 and 2 `here`_, Cymetric can be installed by the
+following command:
+
+.. code-block:: bash
+
+    $ conda install cymetric --yes
 
 .. _`PyNE`: http://github.com/pyne/pyne
-.. _`fuelcycle.org`: http://fuelcycle.org/user/cymetric/index.html
+.. _`fuelcycle.org`: http://fuelcycle.org
+.. _`User Guide`: http://fuelcycle.org/user/index.html
+.. _`here`: http://fuelcycle.org/user/install.html 


### PR DESCRIPTION
companion to https://github.com/cyclus/cyclus.github.com/pull/183
