### PR TITLE
Fix copy/paste bug in Hdf5Back

### DIFF
--- a/cymetric/cyclus.pyx
+++ b/cymetric/cyclus.pyx
@@ -188,7 +188,7 @@ class FullBackend(_FullBackend, object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.flush()
+        self.close()
 
 
 cdef class _SqliteBack(_FullBackend):

--- a/cymetric/cyclus.pyx
+++ b/cymetric/cyclus.pyx
@@ -188,7 +188,7 @@ class FullBackend(_FullBackend, object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        self.flush()
 
 
 cdef class _SqliteBack(_FullBackend):
@@ -205,7 +205,7 @@ cdef class _SqliteBack(_FullBackend):
     def close(self):
         """Closes the backend, flushing it in the process."""
         self.flush()  # just in case
-        (<cpp_cyclus.FullBackend*> self.ptx).Close()
+        (<cpp_cyclus.SqliteBack*> self.ptx).Close()
 
     property name:
         """The name of the database."""
@@ -237,7 +237,7 @@ cdef class _Hdf5Back(_FullBackend):
     property name:
         """The name of the database."""
         def __get__(self):
-            name = (<cpp_cyclus.SqliteBack*> self.ptx).Name()
+            name = (<cpp_cyclus.Hdf5Back*> self.ptx).Name()
             name = name.decode()
             return name
 


### PR DESCRIPTION
Hdf5Back's name method was calling the sql_back c++ name method.  This is a long standing bug, but it seems that something allowed it to work until recent changes in the memory footprint of the hdf_back class.

I also took this opportunity to make some other fixes:

1. SqliteBack close is calling the FullBackend c++ close method.  This might be OK, but following the last refactor, sqlite has its own implementation.

2. FullBackend __exit__ should no call close() anymore because the c++ class no longer has a close method.
