### PR TITLE
Force apt-get update before rebuilding cymetric-deps

### DIFF
--- a/docker/cymetric-deps/Dockerfile
+++ b/docker/cymetric-deps/Dockerfile
@@ -1,7 +1,8 @@
 
 FROM cyclus/cycamore
 
-RUN apt-get install -y --force-yes python3-pip
+RUN apt-get update
+RUN apt-get install -y --force-yes --fix-missing python3-pip
 RUN pip3 install cython numpy
 RUN pip3 install tables
 RUN pip3 install jinja2


### PR DESCRIPTION
Without updating apt-get, it might fail to get some necessary package dependencies.