### PR TITLE
Adding explicit inventory root metrics and metrics

### DIFF
--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -380,31 +380,6 @@ def explicit_inventory_by_nuc(series):
 
 del _invdeps, _invschema
 
-# Compact Explicit Inventory By Agent
-_invdeps = [
-    ('ExplicitInventoryCompact', ('SimId', 'AgentId', 'InventoryName', 'Composition'), 
-        'Quantity')
-    ]
-
-_invschema = [
-    ('SimId', ts.UUID), ('AgentId', ts.INT), 
-    ('InventoryName', ts.STRING), ('Composition', ts.MAP_INT_DOUBLE), 
-    ('Quantity', ts.DOUBLE)
-    ]
-
-@metric(name='ExplicitInventoryCompactByAgent', depends=_invdeps, schema=_invschema)
-def explicit_inventory_by_agent(series):
-    """
-    """
-    inv_index = ['SimId', 'AgentId', 'InventoryName', 'Composition']
-    inv = series[0]
-    inv = inv.groupby(level=inv_index).sum()
-    inv.name = 'Quantity'
-    rtn = inv.reset_index()
-    return rtn
-
-del _invdeps, _invschema
-
 
 # Electricity Generated [MWe-y]
 _egdeps = [('TimeSeriesPower', ('SimId', 'AgentId', 'Time'), 'Value'),]

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -343,7 +343,8 @@ _invschema = [
 
 @metric(name='ExplicitInventoryByAgent', depends=_invdeps, schema=_invschema)
 def explicit_inventory_by_agent(series):
-    """
+    """The Inventory By Agent metric groups the inventories by Agent 
+    (keeping all nuc information)
     """
     inv_index = ['SimId', 'AgentId', 'Time', 'InventoryName', 'NucId']
     inv = series[0]
@@ -369,7 +370,9 @@ _invschema = [
 
 @metric(name='ExplicitInventoryByNuc', depends=_invdeps, schema=_invschema)
 def explicit_inventory_by_nuc(series):
-    """
+    """The Inventory By Nuc metric groups the inventories by nuclide 
+    and discards the agent information it is attached to (providing fuel 
+    cycle-wide nuclide inventories)
     """
     inv_index = ['SimId', 'Time', 'InventoryName', 'NucId']
     inv = series[0]

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -331,21 +331,21 @@ del _transdeps, _transschema
 
 # Explicit Inventory By Agent
 _invdeps = [
-    ('ExplicitInventory', ('SimId', 'AgentId', 'InventoryName', 'NucId'), 
+    ('ExplicitInventory', ('SimId', 'AgentId', 'Time', 'InventoryName', 'NucId'), 
         'Quantity')
     ]
 
 _invschema = [
     ('SimId', ts.UUID), ('AgentId', ts.INT), 
-    ('InventoryName', ts.STRING), ('NucId', ts.INT), 
-    ('Quantity', ts.DOUBLE)
+    ('Time', ts.INT), ('InventoryName', ts.STRING), 
+    ('NucId', ts.INT), ('Quantity', ts.DOUBLE)
     ]
 
 @metric(name='ExplicitInventoryByAgent', depends=_invdeps, schema=_invschema)
 def explicit_inventory_by_agent(series):
     """
     """
-    inv_index = ['SimId', 'AgentId', 'InventoryName', 'NucId']
+    inv_index = ['SimId', 'AgentId', 'Time', 'InventoryName', 'NucId']
     inv = series[0]
     inv = inv.groupby(level=inv_index).sum()
     inv.name = 'Quantity'

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -329,6 +329,83 @@ def transaction_quantity(series):
 del _transdeps, _transschema
 
 
+# Explicit Inventory By Agent
+_invdeps = [
+    ('ExplicitInventory', ('SimId', 'AgentId', 'InventoryName', 'NucId'), 
+        'Quantity')
+    ]
+
+_invschema = [
+    ('SimId', ts.UUID), ('AgentId', ts.INT), 
+    ('InventoryName', ts.STRING), ('NucId', ts.INT), 
+    ('Quantity', ts.DOUBLE)
+    ]
+
+@metric(name='ExplicitInventoryByAgent', depends=_invdeps, schema=_invschema)
+def explicit_inventory_by_agent(series):
+    """
+    """
+    inv_index = ['SimId', 'AgentId', 'InventoryName', 'NucId']
+    inv = series[0]
+    inv = inv.groupby(level=inv_index).sum()
+    inv.name = 'Quantity'
+    rtn = inv.reset_index()
+    return rtn
+
+del _invdeps, _invschema
+
+
+# Explicit Inventory By Nuc
+_invdeps = [
+    ('ExplicitInventory', ('SimId', 'Time', 'InventoryName', 'NucId'), 
+        'Quantity')
+    ]
+
+_invschema = [
+    ('SimId', ts.UUID), ('Time', ts.INT), 
+    ('InventoryName', ts.STRING), ('NucId', ts.INT), 
+    ('Quantity', ts.DOUBLE)
+    ]
+
+@metric(name='ExplicitInventoryByNuc', depends=_invdeps, schema=_invschema)
+def explicit_inventory_by_nuc(series):
+    """
+    """
+    inv_index = ['SimId', 'Time', 'InventoryName', 'NucId']
+    inv = series[0]
+    inv = inv.groupby(level=inv_index).sum()
+    inv.name = 'Quantity'
+    rtn = inv.reset_index()
+    return rtn
+
+del _invdeps, _invschema
+
+# Compact Explicit Inventory By Agent
+_invdeps = [
+    ('ExplicitInventoryCompact', ('SimId', 'AgentId', 'InventoryName', 'Composition'), 
+        'Quantity')
+    ]
+
+_invschema = [
+    ('SimId', ts.UUID), ('AgentId', ts.INT), 
+    ('InventoryName', ts.STRING), ('Composition', ts.MAP_INT_DOUBLE), 
+    ('Quantity', ts.DOUBLE)
+    ]
+
+@metric(name='ExplicitInventoryCompactByAgent', depends=_invdeps, schema=_invschema)
+def explicit_inventory_by_agent(series):
+    """
+    """
+    inv_index = ['SimId', 'AgentId', 'InventoryName', 'Composition']
+    inv = series[0]
+    inv = inv.groupby(level=inv_index).sum()
+    inv.name = 'Quantity'
+    rtn = inv.reset_index()
+    return rtn
+
+del _invdeps, _invschema
+
+
 # Electricity Generated [MWe-y]
 _egdeps = [('TimeSeriesPower', ('SimId', 'AgentId', 'Time'), 'Value'),]
 

--- a/cymetric/root_metrics.py
+++ b/cymetric/root_metrics.py
@@ -62,6 +62,8 @@ build_schedule = root_metric(name='BuildSchedule')
 snapshots = root_metric(name='Snapshots')
 debug_requests = root_metric(name='DebugRequests')
 debug_bids = root_metric(name='DebugBids')
+explicit_inventory = root_metric(name='ExplicitInventory')
+explicit_inventory_compact = root_metric(name='ExplicitInventoryCompact')
 
 #where do these tables come from?
 commod_priority = root_metric(name='CommodPriority')

--- a/tests/test-input.xml
+++ b/tests/test-input.xml
@@ -5,6 +5,8 @@
     <duration>5</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
+    <explicitinventory>true</explicitinventory>
+    <explicitinventorycompact>true</explicitinventorycompact>
   </control>
 
   <archetypes>

--- a/tests/test-input.xml
+++ b/tests/test-input.xml
@@ -5,8 +5,8 @@
     <duration>5</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-    <explicitinventory>true</explicitinventory>
-    <explicitinventorycompact>true</explicitinventorycompact>
+    <explicit_inventory>true</explicit_inventory>
+    <explicit_inventory_compact>true</explicit_inventory_compact>
   </control>
 
   <archetypes>

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -262,16 +262,70 @@ def test_transaction_quantity():
     assert_frame_equal(exp, obs)
 
 
+def test_explicit_inventory_by_agent():
+    exp = pd.DataFrame(np.array([
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'core', 922350000, 3.0), 
+    	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'core', 922380000, 2.0), 
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'core', 922350000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'inventory', 922350000, 1.0),
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'inventory', 922380000, 2.0) 
+	], dtype=ensure_dt_bytes([
+	        ('SimId', 'O'), ('AgentId', '<i8'), ('InventoryName', 'O'), 
+    		('NucId', '<i8'), ('Quantity', '<f8')]))
+        )
+    inv = pd.DataFrame(np.array([
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 1, 'core', 922350000, 1.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922350000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922380000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922350000, 1.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922380000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 2, 'core', 922350000, 2.0),
+        ], dtype=ensure_dt_bytes([
+                ('SimId', 'O'), ('AgentId', '<i8'), ('Time', '<i8'), 
+                ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')]))
+        )
+    series = [inv.set_index(['SimId', 'AgentId', 'InventoryName', 'NucId'])['Quantity']]
+    obs = metrics.explicit_inventory_by_agent.func(series)
+    assert_frame_equal(exp, obs)
+
+
+def test_explicit_inventory_by_nuc():
+    exp = pd.DataFrame(np.array([
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'core', 922350000, 1.0), 
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'inventory', 922350000, 1.0),
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'inventory', 922380000, 2.0), 
+    	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'core', 922350000, 4.0), 
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'core', 922380000, 2.0)
+	], dtype=ensure_dt_bytes([
+	        ('SimId', 'O'), ('Time', '<i8'), ('InventoryName', 'O'), 
+    		('NucId', '<i8'), ('Quantity', '<f8')]))
+        )
+    inv = pd.DataFrame(np.array([
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 1, 'core', 922350000, 1.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922350000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922380000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922350000, 1.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922380000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 2, 'core', 922350000, 2.0),
+        ], dtype=ensure_dt_bytes([
+                ('SimId', 'O'), ('AgentId', '<i8'), ('Time', '<i8'), 
+                ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')]))
+        )
+    series = [inv.set_index(['SimId', 'Time', 'InventoryName', 'NucId'])['Quantity']]
+    obs = metrics.explicit_inventory_by_nuc.func(series)
+    assert_frame_equal(exp, obs)
+
+
 def test_annual_electricity_generated_by_agent():
     exp = pd.DataFrame(np.array([
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 0, 100), 
-	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 1, 100), 
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 1, 100), 
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 0, 200),
-	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 200), 
-	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 3, 1, 400)
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 200), 
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 3, 1, 400)
 	], dtype=ensure_dt_bytes([
 	        ('SimId', 'O'), ('AgentId', '<i8'), ('Year', '<i8'), 
-		('Energy', '<f8')]))
+    		('Energy', '<f8')]))
         )
     tsp = pd.DataFrame(np.array([
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 3, 1200),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -264,19 +264,19 @@ def test_transaction_quantity():
 
 def test_explicit_inventory_by_agent():
     exp = pd.DataFrame(np.array([
-        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'core', 922350000, 3.0), 
-    	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 'core', 922380000, 2.0), 
-	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'core', 922350000, 2.0),
-        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'inventory', 922350000, 1.0),
-	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 'inventory', 922380000, 2.0) 
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 1, 'core', 922350000, 1.0), 
+    	(UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922350000, 4.0), 
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922350000, 1.0),
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922380000, 2.0), 
+	    (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 2, 'core', 922350000, 2.0)
 	], dtype=ensure_dt_bytes([
-	        ('SimId', 'O'), ('AgentId', '<i8'), ('InventoryName', 'O'), 
-    		('NucId', '<i8'), ('Quantity', '<f8')]))
+	        ('SimId', 'O'), ('AgentId', '<i8'), ('Time', '<i8'), 
+            ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')]))
         )
     inv = pd.DataFrame(np.array([
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 1, 'core', 922350000, 1.0),
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922350000, 2.0),
-        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922380000, 2.0),
+        (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 1, 2, 'core', 922350000, 2.0),
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922350000, 1.0),
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 1, 'inventory', 922380000, 2.0),
         (UUID('f22f2281-2464-420a-8325-37320fd418f8'), 2, 2, 'core', 922350000, 2.0),
@@ -284,7 +284,7 @@ def test_explicit_inventory_by_agent():
                 ('SimId', 'O'), ('AgentId', '<i8'), ('Time', '<i8'), 
                 ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')]))
         )
-    series = [inv.set_index(['SimId', 'AgentId', 'InventoryName', 'NucId'])['Quantity']]
+    series = [inv.set_index(['SimId', 'AgentId', 'Time', 'InventoryName', 'NucId'])['Quantity']]
     obs = metrics.explicit_inventory_by_agent.func(series)
     assert_frame_equal(exp, obs)
 

--- a/tests/test_root_metrics.py
+++ b/tests/test_root_metrics.py
@@ -118,6 +118,22 @@ def test_snapshots(db, fname, backend):
 
 
 @dbtest
+def test_inventories(db, fname, backend):
+    r = root_metrics.explicit_inventory(db=db)
+    obs = r()
+    assert_less(0, len(obs))
+    assert_equal('ExplicitInventory', r.name)
+
+
+@dbtest
+def test_inventories_compact(db, fname, backend):
+    r = root_metrics.explicit_inventory_compact(db=db)
+    obs = r()
+    assert_less(0, len(obs))
+    assert_equal('ExplicitInventoryCompact', r.name)
+
+
+@dbtest
 def test_resources_non_existent_filter(db, fname, backend):
     r = root_metrics.resources(db=db)
     obs = r(conds=[('NotAColumn', '!=', 'not-a-value')])


### PR DESCRIPTION
Note the data type for explicit inventory compact does not allow for pandas manipulation so there is only the root metric added