### PR TITLE
removing un-used link to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-docker/cymetric-ci/Dockerfile


### PR DESCRIPTION
@katyhuff hopefully this one should fix #144 .
we had a symlink to a Dockerfile leftover on the root folder that was not used anymore.
it was not able to copy the proper Dockerfile in place of the symlink...
As this Dockerfile is  not used anymore except by the CI, I removed it :)
```
#!/bin/bash -eo pipefail
cp docker/master-ci/Dockerfile .
cp: not writing through dangling symlink './Dockerfile'
Exited with code 1
```