### PR TITLE
Fixing Cymetric master

### DIFF
--- a/tests/test-input.xml
+++ b/tests/test-input.xml
@@ -106,6 +106,7 @@
         </fuel_inrecipes>
         <fuel_outcommods>
           <val>waste</val>
+          <val>waste</val>
         </fuel_outcommods>
         <fuel_outrecipes>
           <val>uox_used_fuel_recipe</val>
@@ -143,6 +144,7 @@
           <val>mox_fuel_recipe</val>
         </fuel_inrecipes>
         <fuel_outcommods>
+          <val>waste</val>
           <val>waste</val>
         </fuel_outcommods>
         <fuel_outrecipes>


### PR DESCRIPTION
Fix input file used for the test.
In the input file some of the reactors had only one output commodity but multiple input ones.


I guess `cyclus` is less tolerant now than it use to be. (I honestly don't know why :) )

Probably a good thing.

@katyhuff @katyhuff @FlanFlanagan if one of you could quickly review this. it should fix the cyclus CI :)