### PR TITLE
Add v1.5.5 to Changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ cymetric Change Log
 ===================
 
 .. current developments
+v1.5.5
+====================
+
+**Added:**
+
+* Monthly electricity generated metric. One for returning electricity by one agent and another for all agents.
+* Added units parameter.
+
+
 v1.5.4
 ====================
 


### PR DESCRIPTION
No news files were added for commits made. Changelog edited based on a review of the commits. Two things added for the 1.5.5 micro-release of Cyclus.