### PR TITLE
Add Dockerhub Authentication

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,9 @@ jobs:
     build:
         docker:
             - image: cyclus/cycamore:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS            
         working_directory: ~/cymetric
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
@@ -26,6 +29,9 @@ jobs:
     nosetest:
         docker:
             - image: cyclus/cycamore:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS         
         working_directory: ~/root
         steps:
             - run:
@@ -46,6 +52,9 @@ jobs:
     deploy: # Cymetric -> Cymetric:latest
         docker:
             - image: circleci/ruby:2.4-node
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
         working_directory: ~/cymetric
         steps:
             - checkout
@@ -67,6 +76,9 @@ jobs:
     deploy_stable: # Cymetric:stable
         docker:
             - image: circleci/ruby:2.4-node
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
         working_directory: ~/cymetric
         steps:
             - checkout
@@ -92,13 +104,16 @@ workflows:
         jobs:
 
             # on a pr // all branch
-            - build
+            - build:
+                context: Dockerhub
             - nosetest:
+                context: Dockerhub
                 requires:
                     - build
 
             # Merge on Master
             - deploy:
+                context: Dockerhub
                 filters:
                     branches:
                         only: master
@@ -108,6 +123,7 @@ workflows:
 
              # The following should now be done on version tag.
             - deploy_stable:
+                context: Dockerhub
                 filters:
                     branches:
                         ignore: /.*/


### PR DESCRIPTION
This PR adds Dockerhub authentication for CI as a result of the changing Dockerhub policy.