### PR TITLE
Fixed memory issue in 'Materials' metric

### DIFF
--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -115,8 +115,8 @@ def materials(rsrcs, comps):
     Resources times the massfrac in Compositions) indexed by the SimId, QualId,
     ResourceId, ObjId, TimeCreated, and NucId.
     """
-    rsrcs = rsrcs[['SimId','ResourceId','ObjId','TimeCreated','Quantity','Units',\
-        'QualId']]
+    rsrcs = rsrcs[['SimId', 'ResourceId', 'ObjId', 'TimeCreated', 'Quantity',
+                   'Units', 'QualId']]
     x = pd.merge(rsrcs, comps, on=['SimId', 'QualId'], how='inner')
     x['Mass'] = x['Quantity'] * x['MassFrac']
     return x

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -115,13 +115,11 @@ def materials(rsrcs, comps):
     Resources times the massfrac in Compositions) indexed by the SimId, QualId,
     ResourceId, ObjId, TimeCreated, and NucId.
     """
+    rsrcs = rsrcs[['SimId','ResourceId','ObjId','TimeCreated','Quantity','Units',\
+        'QualId']]
     x = pd.merge(rsrcs, comps, on=['SimId', 'QualId'], how='inner')
-    x = x.set_index(['SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated',
-                     'NucId', 'Units'])
-    y = x['Quantity'] * x['MassFrac']
-    y.name = 'Mass'
-    z = y.reset_index()
-    return z
+    x['Mass'] = x['Quantity'] * x['MassFrac']
+    return x
 
 
 del _matdeps, _matschema


### PR DESCRIPTION
I modified the 'Materials' metric to remove the memory error described in issue #177. Merging will close Issue #177. This method works, but if there are preferred methods to maintain efficiency of database structure I am open to changes. 