### PR TITLE
Fix pandas, collections, imp warnings

### DIFF
--- a/cymetric/execution.py
+++ b/cymetric/execution.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals, print_function
 import re
 import sys
 import uuid
-from collections import MutableMapping, Sized
+try:
+    from collections.abc import MutableMapping, Sized
+except ImportError:
+    from collections import MutableMapping, Sized
 if sys.version_info[0] > 2:
     str_types = (str, bytes)
 else:

--- a/cymetric/schemas.py
+++ b/cymetric/schemas.py
@@ -2,7 +2,10 @@
 """
 from __future__ import print_function, unicode_literals
 import sys
-from collections import MutableSequence, Iterable
+try:
+    from collections.abc import MutableSequence, Iterable
+except ImportError:
+    from collections import MutableSequence, Iterable
 if sys.version_info[0] > 2:
     str_types = (str, bytes)
 else:

--- a/cymetric/tools.py
+++ b/cymetric/tools.py
@@ -109,7 +109,7 @@ def add_missing_time_step(df, ref_time):
     ref_time.rename(index=str, columns={'TimeStep': 'Time'}, inplace=True)
 
     if 'SimId' in ref_time.columns.values:
-        ref_time.drop('SimId', 1, inplace=True)
+        ref_time.drop('SimId', axis=1, inplace=True)
     df = pd.merge(ref_time, df, how="outer")
     df.fillna(0, inplace=True)
     return df
@@ -129,7 +129,7 @@ def merge(df, base_col, add_df, add_col):
     add_col: columns to be added
     """
     df = pd.merge(add_df[add_col], df, on=base_col)
-    df.drop(base_col[1], 1)
+    df.drop(base_col[1], axis=1)
     return df
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ from __future__ import print_function
 
 import os
 import sys
-import imp
 import argparse
 import platform
 import warnings

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -98,7 +98,7 @@ def test_transactions(db, fname, backend):
 
     # test single receiver
     cal = filters.transactions(evaler, receivers=['Reactor1'])
-    cal = cal.drop(drop_cols, 1)  # SimId change at each test need to drop it
+    cal = cal.drop(drop_cols, axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         ('Reactor1', 'UOX_Source', 'uox', 4),
         ('Reactor1', 'MOX_Source', 'mox', 1),
@@ -115,7 +115,7 @@ def test_transactions(db, fname, backend):
     # test multiple sender
     cal = filters.transactions(
         evaler, receivers=['Reactor1', 'Reactor3'])
-    cal = cal.drop(drop_cols, 1)  # SimId change at each test need to drop it
+    cal = cal.drop(drop_cols, axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         ('Reactor1', 'UOX_Source', 'uox', 4),
         ('Reactor1', 'MOX_Source', 'mox', 1),
@@ -134,7 +134,7 @@ def test_transactions(db, fname, backend):
     # test multiple sender and multiple receiver
     cal = filters.transactions(evaler, senders=['UOX_Source', 'MOX_Source'],
                                receivers=['Reactor1', 'Reactor2'])
-    cal = cal.drop(drop_cols, 1)  # SimId change at each test need to drop it
+    cal = cal.drop(drop_cols, axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         ('Reactor1', 'UOX_Source', 'uox', 4),
         ('Reactor1', 'MOX_Source', 'mox', 1),
@@ -153,7 +153,7 @@ def test_transactions(db, fname, backend):
 
     # test single filters.odity
     cal = filters.transactions(evaler, commodities=['uox'])
-    cal = cal.drop(drop_cols, 1)  # SimId change at each test need to drop it
+    cal = cal.drop(drop_cols, axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         ('Reactor1', 'UOX_Source', 'uox', 4),
         ('Reactor3', 'UOX_Source', 'uox', 3),
@@ -167,7 +167,7 @@ def test_transactions(db, fname, backend):
 
     # test multiple sender
     cal = filters.transactions(evaler, commodities=['uox', 'mox'])
-    cal = cal.drop(drop_cols, 1)  # SimId change at each test need to drop it
+    cal = cal.drop(drop_cols, axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         ('Reactor1', 'UOX_Source', 'uox', 4),
         ('Reactor1', 'MOX_Source', 'mox', 1),
@@ -199,11 +199,11 @@ def test_transactions_nuc(db, fname, backend):
         raise SkipTest
     # test single nuclide selection
     cal = filters.transactions_nuc(evaler, nucs=['942390000'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1)
+    cal = cal.drop('TransactionId', axis=1)
     # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1)
+    cal = cal.drop('ResourceId', axis=1)
     refs = pd.DataFrame(np.array([
         (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
@@ -224,11 +224,11 @@ def test_transactions_nuc(db, fname, backend):
     # test multiple nuclide selection
     cal = filters.transactions_nuc(
         evaler, nucs=['942390000', '922380000'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1)
+    cal = cal.drop('TransactionId', axis=1)
     # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1)
+    cal = cal.drop('ResourceId', axis=1)
     refs = pd.DataFrame(np.array([
         (922380000, 0.7872433760310, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -268,11 +268,11 @@ def test_transactions_activity(db, fname, backend):
 
     # test single nuclide selection
     cal = filters.transactions_activity(evaler, nucs=['942390000'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1)
+    cal = cal.drop('TransactionId', axis=1)
     # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1)
+    cal = cal.drop('ResourceId', axis=1)
     refs = pd.DataFrame(np.array([
         (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
@@ -292,11 +292,11 @@ def test_transactions_activity(db, fname, backend):
     # test multiple nuclide selection
     cal = filters.transactions_activity(
         evaler, nucs=['942390000', '922380000'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1)
+    cal = cal.drop('TransactionId', axis=1)
     # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1)
+    cal = cal.drop('ResourceId', axis=1)
 
     refs = pd.DataFrame(np.array([
         (922380000, 9790360.331530, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -336,11 +336,11 @@ def test_transactions_decayheat(db, fname, backend):
 
     # test single nuclide selection
     cal = filters.transactions_decayheat(evaler, nucs=['942390000'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1)
+    cal = cal.drop('TransactionId', axis=1)
     # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1)
+    cal = cal.drop('ResourceId', axis=1)
     refs = pd.DataFrame(np.array([
         (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
@@ -360,11 +360,11 @@ def test_transactions_decayheat(db, fname, backend):
     # test multiple nuclide selection
     cal = filters.transactions_decayheat(
         evaler, nucs=['942390000', '922380000'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1)
+    cal = cal.drop('TransactionId', axis=1)
     # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1)
+    cal = cal.drop('ResourceId', axis=1)
     refs = pd.DataFrame(np.array([
         (922380000, 2.609253035160e26, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -403,7 +403,7 @@ def test_inventories(db, fname, backend):
         raise SkipTest
     cal = filters.inventories(evaler, facilities=['Reactor1'],
                               nucs=['94239'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core', 942390000, 0.0444814879803),
         (15, 'Reactor1', 2, 'core', 942390000, 0.0444814879803),
@@ -421,7 +421,7 @@ def test_inventories(db, fname, backend):
 
     cal = filters.inventories(evaler, facilities=['Reactor1'],
                               nucs=['94239', '92235'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core', 922350000, 0.00157922442534),
         (15, 'Reactor1', 1, 'core', 942390000, 0.0444814879803),
@@ -458,7 +458,7 @@ def test_inventories_activity(db, fname, backend):
 
     cal = filters.inventories_activity(evaler, facilities=['Reactor1'],
                                        nucs=['94239'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core', 942390000, 0.0444814879803, 2.44036364223e+13),
         (15, 'Reactor1', 2, 'core', 942390000, 0.0444814879803, 2.44036364223e+13),
@@ -476,7 +476,7 @@ def test_inventories_activity(db, fname, backend):
 
     cal = filters.inventories_activity(evaler, facilities=['Reactor1'],
                                        nucs=['94239', '92235'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core', 922350000, 0.00157922442534, 29671782.9213),
         (15, 'Reactor1', 1, 'core', 942390000, 0.04448148798, 2.44036364223e+13),
@@ -512,7 +512,7 @@ def test_inventories_decayheat(db, fname, backend):
 
     cal = filters.inventories_decayheat(evaler, facilities=['Reactor1'],
                                         nucs=['94239'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core', 942390000,
          0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
@@ -536,7 +536,7 @@ def test_inventories_decayheat(db, fname, backend):
 
     cal = filters.inventories_decayheat(evaler, facilities=['Reactor1'],
                                         nucs=['94239', '92235'])
-    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    cal = cal.drop('SimId', axis=1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core', 922350000,
          0.00157922442534, 29671782.9213, 8.65609466244e+26),


### PR DESCRIPTION
fixes a few deprecated (or soon-to-be deprecated) imports and syntax
- Pandas drop adds axis keyword which will eventually be required
- `MutableSequence` and `Iterable` from collections is now part of collections.abc.
- imp in setup.py is deprecated and unused anyway (?), so removed