### PR TITLE
Update version_tag in `publish_release.yml`

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Tag as stable
         if: ${{ github.repository_owner == 'cyclus' }}
         run: |
-          echo "version_tag=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "version_tag=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
           echo "stable_tag=stable" >> "$GITHUB_ENV"
 
       - name: Log in to the Container registry

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ cymetric Change Log
 
 .. current developments
 **Added:**
-* GitHub workflows for CI (#188, #190)
+* GitHub workflows for CI (#188, #190, #191)
 
 **Changed**
 * Converted test suite from nose to pytest (#188)


### PR DESCRIPTION
`${{ github.ref_name }} does not exist in the context of a workflow triggered by a release