### PR TITLE
Push images and caches to `github.repository_owner`

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,7 +3,7 @@ name: Build/Test for PR and collaborator push
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      pull-requests: write
       
     strategy:
       fail-fast: false
@@ -67,13 +66,20 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=${{ matrix.cycamore_tag }}
 
-      - name: PR Comment
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: thollander/actions-comment-pull-request@v2
+      - name: Construct Artifact
+        run: |
+          echo "BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
+          steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
+          '**Skipped due to upstream failure** :warning:'}}" >> $GITHUB_ENV
+
+          echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> $GITHUB_ENV
+
+          echo "Build against `cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}` - ${{ env.BUILD_STATUS }}" 
+            > ${{ env.ARTIFACT_NAME }}.txt
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
         with:
-          comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}
-          message: |
-            ## Build statuses using cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}:${{ matrix.cycamore_tag }}
-            - Cymetric: ${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
-                steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
-                '**Skipped due to upstream failure** :warning:'}}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_NAME }}.txt
+          

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,7 +3,7 @@ name: Build/Test for PR and collaborator push
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -66,7 +66,7 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=${{ matrix.cycamore_tag }}
 
-      - name: Construct Artifact
+      - name: Export Environment Variables
         run: |
           echo "BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
           steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
@@ -74,6 +74,8 @@ jobs:
 
           echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> "$GITHUB_ENV"
 
+      - name: Construct Artifact
+        run: |
           echo "Build against `cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}` - ${{ env.BUILD_STATUS }}" 
             > ${{ env.ARTIFACT_NAME }}.txt
       

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -74,10 +74,7 @@ jobs:
 
           echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> "$GITHUB_ENV"
 
-      - name: Construct Artifact
-        run: |
-          echo "Build against \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" 
-            > ${{ env.ARTIFACT_NAME }}.txt
+          echo "Build against \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
       
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -74,6 +74,8 @@ jobs:
 
           echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> "$GITHUB_ENV"
 
+      - name: Construct Artifact
+        run: |
           echo "Build against \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
       
       - name: Upload Artifact

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -59,8 +59,8 @@ jobs:
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max,ignore-error=true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max,ignore-error=true
           file: docker/Dockerfile
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -70,9 +70,9 @@ jobs:
         run: |
           echo "BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
           steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
-          '**Skipped due to upstream failure** :warning:'}}" >> $GITHUB_ENV
+          '**Skipped due to upstream failure** :warning:'}}" >> "$GITHUB_ENV"
 
-          echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> "$GITHUB_ENV"
 
           echo "Build against `cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}` - ${{ env.BUILD_STATUS }}" 
             > ${{ env.ARTIFACT_NAME }}.txt

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,7 +3,7 @@ name: Build/Test for PR and collaborator push
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'
@@ -67,20 +67,36 @@ jobs:
             cycamore_tag=${{ matrix.cycamore_tag }}
 
       - name: Export Environment Variables
+        if: github.event_name == 'pull_request'
         run: |
-          echo "BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
+          echo "BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '**Success** :white_check_mark:' || 
           steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
           '**Skipped due to upstream failure** :warning:'}}" >> "$GITHUB_ENV"
 
           echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}" >> "$GITHUB_ENV"
 
       - name: Construct Artifact
+        if: github.event_name == 'pull_request'
         run: |
-          echo "Build against \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
+          echo "Build FROM \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
       
       - name: Upload Artifact
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACT_NAME }}.txt
           
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Save PR number to file
+        run: |
+          echo "${{ github.event.number }}" > pr_number
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.triggering_actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -59,8 +59,8 @@ jobs:
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -67,6 +67,11 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=${{ matrix.cycamore_tag }}
 
+      - name: debug
+        run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.event }}
+
       - name: PR Comment
         if: ${{ github.event_name == 'pull_request_target' }}
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,7 +3,7 @@ name: Build/Test for PR and collaborator push
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'
@@ -73,7 +73,7 @@ jobs:
           echo ${{ github.event }}
 
       - name: PR Comment
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Construct Artifact
         run: |
-          echo "Build against `cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}` - ${{ env.BUILD_STATUS }}" 
+          echo "Build against \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" 
             > ${{ env.ARTIFACT_NAME }}.txt
       
       - name: Upload Artifact

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Construct Artifact
         if: github.event_name == 'pull_request'
         run: |
-          echo "Build FROM \`cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
+          echo "Build \`FROM cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ matrix.cycamore_tag }}\` - ${{ env.BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
       
       - name: Upload Artifact
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.triggering_actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -59,8 +59,8 @@ jobs:
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,7 +3,7 @@ name: Build/Test for PR and collaborator push
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'
@@ -67,13 +67,8 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=${{ matrix.cycamore_tag }}
 
-      - name: debug
-        run: |
-          echo ${{ github.event_name }}
-          echo ${{ github.event }}
-
       - name: PR Comment
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request_target' }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -68,7 +68,7 @@ jobs:
             cycamore_tag=${{ matrix.cycamore_tag }}
 
       - name: PR Comment
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request_target' }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cycamore_tag }}

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -30,3 +30,4 @@ jobs:
           pr_number: ${{ env.PR_NUMBER }}
           comment_tag: build_status_report
           filePath: artifacts_merged.md
+

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pr-comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -21,11 +21,12 @@ jobs:
           
       - name: debug
         run: |
-          ls -l
+          ls -R
 
       - name: Merge artifacts
         run: |
           cat ./*.txt > artifacts_merged.txt
+          cat artifacts_merged.txt
 
       - name: PR Comment
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,34 @@
+name: Comment on PR
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Build/Test for PR and collaborator push"]
+    types:
+      - completed
+
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          merge-multiple: true
+          
+      - name: debug
+        run: |
+          ls -l
+
+      - name: Merge artifacts
+        run: |
+          cat ./*.txt > artifacts_merged.txt
+
+      - name: PR Comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: build_status_report
+          filePath: artifacts_merged.txt

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,7 +1,5 @@
 name: Comment on PR
 
-# read-write repo token
-# access to secrets
 on:
   workflow_run:
     workflows: ["Build/Test for PR and collaborator push"]

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -11,25 +11,24 @@ on:
 jobs:
   pr-comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
           merge-multiple: true
-          
-      - name: debug
-        run: |
-          ls -R
 
-      - name: Merge artifacts
+      - name: Merge artifacts and get PR number
         run: |
-          cat ./*.txt > artifacts_merged.txt
-          cat artifacts_merged.txt
+          echo "### Build Status Report" > artifacts_merged.md
+          cat ./*.txt >> artifacts_merged.md
+          echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 
       - name: PR Comment
         uses: thollander/actions-comment-pull-request@v2
         with:
+          pr_number: ${{ env.PR_NUMBER }}
           comment_tag: build_status_report
-          filePath: artifacts_merged.txt
+          filePath: artifacts_merged.md

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.triggering_actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -52,11 +52,11 @@ jobs:
       - name: Build and Test Cymetric
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
+          tags: ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -13,7 +13,9 @@ on:
 jobs:
   build-cymetric-and-push:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         ubuntu_versions : [

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.triggering_actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -54,11 +54,11 @@ jobs:
       - name: Build and Test Cymetric
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      
     strategy:
       matrix:
         ubuntu_versions : [

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Build and Test Cymetric
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
-          tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Build and Test Cymetric
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.version_tag }}
-            ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.stable_tag }}
+            ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.version_tag }}
+            ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.stable_tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.triggering_actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -52,13 +52,13 @@ jobs:
       - name: Build and Test Cymetric
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.version_tag }}
-            ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.stable_tag }}
+            ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.version_tag }}
+            ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.stable_tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.triggering_actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -52,13 +52,13 @@ jobs:
       - name: Build and Test Cymetric
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.version_tag }}
-            ghcr.io/${{ github.triggering_actor }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.stable_tag }}
+            ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.version_tag }}
+            ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.stable_tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ cymetric Change Log
 
 .. current developments
 **Added:**
-* GitHub workflows for CI (#188, #190, #191)
+* GitHub workflows for CI (#188, #190, #191, #193)
 
 **Changed**
 * Converted test suite from nose to pytest (#188)

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Dependencies
 First, please check to make sure you have all of the dependencies.
 
 Required dependencies:
-
+ 
 * Cyclus and its dependencies
 * `Jinja2 <http://jinja.pocoo.org/docs/dev/>`_
 * `pandas <http://pandas.pydata.org/>`_


### PR DESCRIPTION
Should solve an issue discovered by @abachma2 in #184.  Forks of cymetric do not have permission to push to the cyclus GHCR.  Adding the `ignore-error` parameter to `--cache-to` should let the workflow continue without error when this happens.  This should not have a significant impact the efficacy of our caching strategy since caches will be pushed whenever the workflow is run from the upstream repository `cyclus/cymetric`.

I intentionally did not include this parameter in `publish_latest.yml` and `publish_release.yml`. Those workflows need to push to GHCR to publish images.  They will publish official images when run from the upstream repo, but any changes to the workflow should come from a branch off the upstream (NOT from a fork, otherwise this 403 forbidden will occur) because on a PR it will publish irrelevant images tagged `:ci-image-cache` to prove functionality of the workflow