### PR TITLE
Use `python3` instead of `python`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Since last release
 
 **Changed:**
 
+* Rely on `python3` in environment instead of `python` (#196)
+
 **Fixed:**
 
 **Removed:**

--- a/README.rst
+++ b/README.rst
@@ -40,13 +40,13 @@ Then build and install to the same location Cyclus is installed:
 .. code-block:: bash
 
     $ cd cymetric
-    $ python -m pip install --target $(python -m site --user-site) .
+    $ python3 -m pip install --target $(python3 -m site --user-site)
 
 Next, run the tests to ensure everything is working properly:
 
 .. code-block:: bash
 
-    $ python -m pytest tests/
+    $ python3 -m pytest tests/
 
 Installation via Binary
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/cyclus/cycamore_${ubuntu_version}_${pkg_mgr}/cycamore:${cycamore_ta
 
 COPY . /cymetric
 WORKDIR /cymetric
-RUN python -m pip install --target $(python -m site --user-site) .
+RUN python3 -m pip install --target $(python3 -m site --user-site) .
 
 FROM cymetric as cymetric-pytest
-RUN cd tests && python -m pytest
+RUN cd tests && python3 -m pytest

--- a/scripts/cymetric
+++ b/scripts/cymetric
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Cymetric entry point."""
 from cymetric.main import main
 main()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Welcome to cymetric's setup.py script. This is a little non-standard because pyne
 is a multilanguage project.  Still, this script follows a predicatable ordering:
 


### PR DESCRIPTION
No longer require version agnostic `python` in the environment