### PR TITLE
Pin numpy to <2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Since last release
 **Changed:**
 
 * Rely on `python3` in environment instead of `python` (#196)
+* Pinned ``numpy<2.0.0`` in ``pyproject.toml`` (#198)
 
 **Fixed:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     'pandas',
-    'numpy',
+    'numpy<2.0.0',
     'Jinja2',
     'matplotlib',
 ]


### PR DESCRIPTION
Resolves an issue described in #197.  The pin should be removed when the latest dependencies are compatible with each other... I believe as of now the blocker is `pytables` not supporting `numpy==2.0.0`