### PR TITLE
Remove `numpy` pin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Since last release
 
 * Rely on `python3` in environment instead of `python` (#196)
 * Pinned ``numpy<2.0.0`` in ``pyproject.toml`` (#198)
+* Unpinned ``numpy`` in ``pyproject.toml`` (#203)
 
 **Fixed:**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,11 @@ ARG pkg_mgr=apt
 ARG ubuntu_version=22.04
 ARG cycamore_tag=latest
 
-FROM ghcr.io/cyclus/cycamore_${ubuntu_version}_${pkg_mgr}/cycamore:${cycamore_tag} as cymetric
+FROM ghcr.io/cyclus/cycamore_${ubuntu_version}_${pkg_mgr}/cycamore:${cycamore_tag} AS cymetric
 
 COPY . /cymetric
 WORKDIR /cymetric
 RUN python3 -m pip install --target $(python3 -m site --user-site) .
 
-FROM cymetric as cymetric-pytest
+FROM cymetric AS cymetric-pytest
 RUN cd tests && python3 -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     'pandas',
-    'numpy<2.0.0',
+    'numpy',
     'Jinja2',
     'matplotlib',
 ]


### PR DESCRIPTION
Closes #199.  CI fails on the conda:stable images because those stable images do not have the newer release of `pytables` that supports `numpy>=2.0.0`.